### PR TITLE
Update stress test to use a signed certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 as builder
+FROM golang:1.15 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 COPY . /go/src/github.com/virtual-kubelet/virtual-kubelet

--- a/Dockerfile.stress_test
+++ b/Dockerfile.stress_test
@@ -1,4 +1,4 @@
-FROM golang:1.12 as builder
+FROM golang:1.15 as builder
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 COPY . /go/src/github.com/virtual-kubelet/virtual-kubelet
@@ -6,12 +6,17 @@ WORKDIR /go/src/github.com/virtual-kubelet/virtual-kubelet
 ARG BUILD_TAGS=""
 RUN make VK_BUILD_TAGS="${BUILD_TAGS}" build
 RUN cp bin/virtual-kubelet /usr/bin/virtual-kubelet
+RUN go build ./cmd/lwm2m-bootstrapper
+RUN cp lwm2m-bootstrapper /usr/bin/lwm2m-bootstrapper
 
 FROM ubuntu:18.04
 RUN apt update
-RUN apt install -y openssl uuid gettext-base ca-certificates
+RUN apt install -y openssl uuid gettext-base ca-certificates curl jq
+# Fix for "139752666972608:error:2406F079:random number generator:RAND_load_file:Cannot open file:../crypto/rand/randfile.c:88:Filename=/root/.rnd"
+RUN openssl rand -out ~/.rnd -writerand ~/.rnd
 COPY --from=builder /usr/bin/virtual-kubelet /usr/bin/virtual-kubelet
+COPY --from=builder /usr/bin/lwm2m-bootstrapper /usr/bin/lwm2m-bootstrapper
 WORKDIR /root
 COPY ./cmd/virtual-kubelet/internal/commands/stress/scripts .
 COPY ./scripts/stress-test.sh .
-ENTRYPOINT ./stress-test.sh $KAAS_URI $ACCOUNT_ID $NODES
+ENTRYPOINT ["./stress-test.sh"]

--- a/cmd/lwm2m-bootstrapper/device.go
+++ b/cmd/lwm2m-bootstrapper/device.go
@@ -1,0 +1,454 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	piondtls "github.com/pion/dtls/v2"
+	"github.com/plgd-dev/go-coap/v2/dtls"
+	"github.com/plgd-dev/go-coap/v2/message"
+	"github.com/plgd-dev/go-coap/v2/message/codes"
+	"github.com/plgd-dev/go-coap/v2/mux"
+)
+
+// Query parameters used by device management over coap
+// - aid - Account ID
+// - iep - Device ID (or Bootstrap ID)
+// - ep - Endpoint Name
+
+// Certificates
+// - Developer Mode Bootstrap Certificate
+//		- CN - Bootstrap ID
+//		- OU - Account
+//		- L - Locality (E.X. "Cambridge")
+// - Production Mode Bootstrap Certificate
+//		- CN - Endpoint Name
+//		- OU - (Optional)
+//		- L -  (Optional)
+// - Production Mode LWM2M Certificate
+//		- CN - Endpoint Name
+//		- OU - Account (Optional but required for KaaS)
+//		- L -  Device ID (Optional but required for KaaS)
+
+// DeviceFromBootstrapCredentials initializes a new Device object with bootstrap credentials
+func DeviceFromBootstrapCredentials(store Store, bsURL string, certPath string, keyPath string) (*Device, error) {
+
+	certificate, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		log.Fatalf("Failed loading bootstrap certificate: %v", err)
+	}
+
+	bsID, err := CNFromCert(certificate)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid certificate: %w", err)
+	}
+
+	parsedBsURL, err := parseCoapURL(bsURL)
+	if err != nil {
+		return nil, fmt.Errorf("Bootstrap URL invalid: %v", err)
+	}
+	account := parsedBsURL.Query()["aid"][0]
+
+	return &Device{
+		AccountID: account,
+		Store:     store,
+
+		BootstrapID:   &bsID,
+		BootstrapURL:  parsedBsURL,
+		BootstrapCert: &certificate,
+	}, nil
+}
+
+// DeviceFromLWM2MCredentials initializes a new Device object with LWM2M credentials
+func DeviceFromLWM2MCredentials(store Store, url string, certPath string, keyPath string) (*Device, error) {
+
+	certificate, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		log.Fatalf("Failed loading LWM2M certificate: %v", err)
+	}
+
+	name, err := CNFromCert(certificate)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid certificate: %w", err)
+	}
+
+	parsedURL, err := parseCoapURL(url)
+	if err != nil {
+		return nil, fmt.Errorf("LWM2M URL invalid: %v", err)
+	}
+	account := parsedURL.Query()["aid"][0]
+
+	return &Device{
+		AccountID: account,
+		Store:     store,
+
+		EndpointName: &name,
+		Lwm2mURL:     parsedURL,
+		Lwm2mCert:    &certificate,
+	}, nil
+}
+
+// parseCoapURL converts a string into a URL and validates it
+// 	When Valid:
+// 	- coapURL.Query()["aid"][0] exists and can be accessed to get account ID
+//  - URL protocol is coap
+func parseCoapURL(coapURL string) (*url.URL, error) {
+	parsedURL, err := url.Parse(coapURL)
+	if err != nil {
+		return nil, fmt.Errorf("URL invalid: %v", err)
+	}
+	accounts, ok := parsedURL.Query()["aid"]
+	if !ok || len(accounts) == 0 {
+		return nil, fmt.Errorf("URL is missing account query parameter - 'aid'")
+	}
+	if len(accounts) != 1 {
+		return nil, fmt.Errorf("URL must have exactly one account query parameter - 'aid'")
+	}
+	if parsedURL.Scheme != "coaps" {
+		return nil, fmt.Errorf("URL scheme \"%v\" not supported, must be \"coap\"", parsedURL.Scheme)
+	}
+	return parsedURL, nil
+}
+
+// Device is a LWM2M device
+type Device struct {
+	AccountID string
+	Store     Store
+
+	// Bootstrap values
+	BootstrapID   *string
+	BootstrapURL  *url.URL // Bootstrap server URL as reported by Pelion
+	BootstrapCert *tls.Certificate
+
+	// LWM2M values
+	EndpointName *string
+	Lwm2mURL     *url.URL // LWM2M server URL as reported by Pelion
+	Lwm2mCert    *tls.Certificate
+}
+
+// Register performs LWM2M registration followed by deregistration
+func (d *Device) Register(ctx context.Context) error {
+	err := d.readyForRegister()
+	if err != nil {
+		return fmt.Errorf("Unable to register: %w", err)
+	}
+
+	config := &piondtls.Config{
+		Certificates:         []tls.Certificate{*d.Lwm2mCert},
+		InsecureSkipVerify:   true,
+		ExtendedMasterSecret: piondtls.RequireExtendedMasterSecret,
+	}
+
+	m := mux.NewRouter()
+	m.DefaultHandleFunc(mux.HandlerFunc(d.handleDefault))
+
+	co, err := dtls.Dial(d.Lwm2mURL.Host, config, dtls.WithMux(m))
+	if err != nil {
+		return fmt.Errorf("Error dialing: %w", err)
+	}
+	defer co.Close()
+
+	options := []message.Option{
+		{ID: 15, Value: []byte(fmt.Sprintf("ep=%v", *d.EndpointName))},
+	}
+	for key, values := range d.Lwm2mURL.Query() {
+		for _, value := range values {
+			options = append(options, message.Option{ID: 15, Value: []byte(fmt.Sprintf("%v=%v", key, value))})
+		}
+	}
+
+	resp, err := co.Post(ctx, "rd", 110, strings.NewReader("</1>,</2>,</3>,</4>,</5>"), options...)
+	if err != nil {
+		return fmt.Errorf("Error sending request: %w", err)
+	}
+	expected := codes.Created
+	if resp.Code() != expected {
+		return fmt.Errorf("Wrong return code, expected \"%v\" got \"%v\": %v", expected, resp.Code(), resp)
+	}
+	locationPath := ""
+	for _, option := range resp.Options() {
+		if option.ID != message.LocationPath {
+			continue
+		}
+		locationPath = locationPath + "/" + string(option.Value)
+	}
+	log.Printf("Device registered\n")
+
+	resp, err = co.Delete(ctx, locationPath)
+	if err != nil {
+		return fmt.Errorf("Error sending request: %w", err)
+	}
+	expected = codes.Deleted
+	if resp.Code() != expected {
+		return fmt.Errorf("Wrong return code, expected \"%v\" got \"%v\": %v", expected, resp.Code(), resp)
+	}
+	log.Printf("Device de-registered\n")
+
+	return nil
+}
+
+// Bootstrap performs LWM2M bootstrap
+func (d *Device) Bootstrap(ctx context.Context) error {
+	err := d.readyForBootstrap()
+	if err != nil {
+		return fmt.Errorf("Unable to bootstrap: %w", err)
+	}
+
+	config := &piondtls.Config{
+		Certificates:         []tls.Certificate{*d.BootstrapCert},
+		InsecureSkipVerify:   true,
+		ExtendedMasterSecret: piondtls.RequireExtendedMasterSecret,
+	}
+
+	var once sync.Once
+	bsDone := make(chan struct{})
+	handleBsDone := func(w mux.ResponseWriter, r *mux.Message) {
+		log.Printf("Bootstrap complete")
+		once.Do(func() { close(bsDone) })
+	}
+
+	m := mux.NewRouter()
+	m.Handle("/0", mux.HandlerFunc(d.bsHandleObjectID))
+	m.Handle("/1", mux.HandlerFunc(d.bsHandleObjectID))
+	m.Handle("/3", mux.HandlerFunc(d.bsHandleObjectID))
+	m.Handle("/bs", mux.HandlerFunc(handleBsDone))
+	m.DefaultHandleFunc(mux.HandlerFunc(d.bsHandleDefault))
+
+	co, err := dtls.Dial(d.BootstrapURL.Host, config, dtls.WithMux(m))
+	if err != nil {
+		return fmt.Errorf("Error dialing: %w", err)
+	}
+	defer co.Close()
+
+	resp, err := co.Post(context.Background(), "bs", message.TextPlain, nil,
+		message.Option{ID: 15, Value: []byte(fmt.Sprintf("ep=%v", *d.BootstrapID))},
+		message.Option{ID: 15, Value: []byte(fmt.Sprintf("aid=%v", d.AccountID))},
+	)
+
+	if err != nil {
+		return fmt.Errorf("Error sending request: %w", err)
+	}
+	if resp.Code() != codes.Changed {
+		return fmt.Errorf("Wrong return code: %v", resp)
+	}
+
+	timeout := time.NewTimer(time.Second * 10)
+	defer timeout.Stop()
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("Context expired waiting for bootstrap to finish")
+	case <-timeout.C:
+		return fmt.Errorf("Timeout waiting for bootstrap to finish")
+	case <-bsDone:
+	}
+
+	err = d.loadLW2MCredentialsFromStore()
+	if err != nil {
+		return fmt.Errorf("Invalid credentials returned from bootstrap: %v", err)
+	}
+
+	return nil
+}
+
+func (d *Device) bsHandleObjectID(w mux.ResponseWriter, r *mux.Message) {
+	requestPath, err := r.Options.Path()
+	if err != nil {
+		log.Printf("Error extracting path for request %v", r)
+		setResponse(w, codes.BadRequest)
+		return
+	}
+	objectID, err := strconv.Atoi(requestPath)
+	if err != nil {
+		log.Printf("Invalid Path %v", requestPath)
+		setResponse(w, codes.BadRequest)
+		return
+	}
+
+	if r.Code == codes.DELETE {
+		log.Printf("DELETE %v:  %v from %v\n", objectID, r, w.Client().RemoteAddr())
+		setResponse(w, codes.Deleted)
+		return
+	} else if r.Code == codes.PUT {
+		log.Printf("PUT %v:  %v from %v\n", objectID, r, w.Client().RemoteAddr())
+
+		// Check for the right Media Type format
+		format, err := r.Options.ContentFormat()
+		if err != nil || format != 99 {
+			setResponse(w, codes.UnsupportedMediaType)
+			return
+		}
+
+		if r.Body == nil {
+			log.Printf("Nil body for a put request")
+			setResponse(w, codes.BadRequest)
+			return
+		}
+
+		data, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			setResponse(w, codes.InternalServerError)
+			return
+		}
+
+		err = storeObjectInstanceTLV(d.Store, objectID, data)
+		if err != nil {
+			log.Printf("Error storing object: %v", err)
+			setResponse(w, codes.BadRequest)
+			return
+		}
+
+		setResponse(w, codes.Changed)
+
+	} else {
+		log.Printf("Message not allowed: %v\n", r.Code)
+		setResponse(w, codes.MethodNotAllowed)
+	}
+}
+
+func (d *Device) handleDefault(w mux.ResponseWriter, r *mux.Message) {
+	log.Printf("UNSUPPORTED: %v", r)
+	setResponse(w, codes.Forbidden)
+}
+
+func (d *Device) bsHandleDefault(w mux.ResponseWriter, r *mux.Message) {
+	log.Printf("UNSUPPORTED: %v", r)
+	setResponse(w, codes.Forbidden)
+}
+
+// setResponse is a helper which sets the response and logs if this failed
+func setResponse(w mux.ResponseWriter, code codes.Code) {
+	err := w.SetResponse(code, message.TextPlain, nil)
+	if err != nil {
+		log.Printf("Error setting response: %v", err)
+	}
+}
+
+func storeObjectInstanceTLV(s Store, objectID int, data []byte) error {
+
+	tlvs, _, err := TLVFromBytes(data)
+
+	if err != nil {
+		return fmt.Errorf("Error decoding TLV: %w", err)
+	}
+
+	if tlvs.Type != ObjectInstance {
+		return fmt.Errorf("Invalid TLV type - Expected %v got %v", ObjectInstance, tlvs.Type)
+	}
+
+	for _, child := range tlvs.Children {
+		if child.Type != Resource {
+			continue
+		}
+		objectIntance := tlvs.Identifier
+		resource := child.Identifier
+		s.Put(fmt.Sprintf("/%v/%v/%v", objectID, objectIntance, resource), child.Value)
+	}
+	return nil
+}
+
+// CNFromCert retrieves the endpoint name from a TLS certificate
+func CNFromCert(tlsCert tls.Certificate) (string, error) {
+	if len(tlsCert.Certificate) == 0 {
+		return "", fmt.Errorf("No certificate data present")
+	}
+	cert, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	if err != nil {
+		return "", fmt.Errorf("Error parsing certificate: %w", err)
+	}
+	return cert.Subject.CommonName, nil
+}
+
+// loadLW2MCredentialsFromStore loads and validates the LWM2M credentials in the store
+func (d *Device) loadLW2MCredentialsFromStore() error {
+	cert := tls.Certificate{}
+
+	// LWM2M URL
+	data, err := d.Store.Get("/0/0/0")
+	if err != nil {
+		return fmt.Errorf("Error retrieving LWM2M URL: %w", err)
+	}
+	lwm2mURL, err := parseCoapURL(string(data))
+	if err != nil {
+		return fmt.Errorf("LWM2M URL invalid: %v", err)
+	}
+	account := lwm2mURL.Query()["aid"][0]
+	if account != d.AccountID {
+		log.Printf("Warning: Account mismatch, %v != %v", account, d.AccountID)
+	}
+
+	// Device Certificate
+	data, err = d.Store.Get("/0/0/3")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Device Certificate: %w", err)
+	}
+	_, err = x509.ParseCertificate(data)
+	if err != nil {
+		return fmt.Errorf("Device Certificate is invalid: %w", err)
+	}
+	cert.Certificate = append(cert.Certificate, data)
+
+	// Device Private Key
+	data, err = d.Store.Get("/0/0/5")
+	if err != nil {
+		return fmt.Errorf("Error retrieving Device Private Key: %w", err)
+	}
+	privateKey, err := x509.ParsePKCS8PrivateKey(data)
+	if err != nil {
+		return fmt.Errorf("Device Private Key is invalid: %w", err)
+	}
+	cert.PrivateKey = privateKey
+
+	endpointName, err := CNFromCert(cert)
+	if err != nil {
+		return fmt.Errorf("Invalid Device Certificate: %v", err)
+	}
+
+	if d.EndpointName != nil && *d.EndpointName != endpointName {
+		log.Printf("Warning: Endpoint name changed from \"%v\" to \"%v\"", d.EndpointName, endpointName)
+	}
+	d.EndpointName = &endpointName
+	d.Lwm2mURL = lwm2mURL
+	d.Lwm2mCert = &cert
+
+	// Sanity check
+	err = d.readyForRegister()
+	if err != nil {
+		log.Fatalf("Internal error causing not ready for registration: %v", err)
+	}
+	return nil
+}
+
+func (d *Device) readyForBootstrap() error {
+	if d.BootstrapID == nil {
+		return fmt.Errorf("BootstrapID missing")
+	}
+	if d.BootstrapURL == nil {
+		return fmt.Errorf("BootstrapURL missing")
+	}
+	if d.BootstrapCert == nil {
+		return fmt.Errorf("BootstrapCert missing")
+	}
+	return nil
+}
+
+func (d *Device) readyForRegister() error {
+	if d.EndpointName == nil {
+		return fmt.Errorf("EndpointName missing")
+	}
+	if d.Lwm2mURL == nil {
+		return fmt.Errorf("Lwm2mURL missing")
+	}
+	if d.Lwm2mCert == nil {
+		return fmt.Errorf("Lwm2mCert missing")
+	}
+	return nil
+}

--- a/cmd/lwm2m-bootstrapper/main.go
+++ b/cmd/lwm2m-bootstrapper/main.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+const modeOptionBootstrap = "bootstrap"
+const modeOptionLWM2M = "lwm2m"
+const storeOptionMem = "memory"
+const storeOptionFS = "filesystem"
+
+const flagCoapURL = "coap-url"
+const flagCoapCert = "coap-cert"
+const flagCoapKey = "coap-key"
+const flagMode = "mode"
+const flagCertOut = "dump-cert"
+const flagKeyOut = "dump-key"
+const flagStore = "store"
+const flagStoreDir = "store-filesystem-dir"
+
+var valueCoapURL string
+var valueCoapCert string
+var valueCoapKey string
+var valueMode string
+var valueCertOut string
+var valueKeyOut string
+var valueStore string
+var valueStoreDir string
+
+func main() {
+
+	flag.StringVar(&valueCoapURL, flagCoapURL, "", "URL to use")
+	flag.StringVar(&valueCoapCert, flagCoapCert, "", "Device certificate")
+	flag.StringVar(&valueCoapKey, flagCoapKey, "", "Device private key")
+	flag.StringVar(&valueMode, flagMode, "", "Connect mode - \""+modeOptionBootstrap+"\" or \""+modeOptionLWM2M+"\"")
+	flag.StringVar(&valueCertOut, flagCertOut, "", "Location to retreived device certificate")
+	flag.StringVar(&valueKeyOut, flagKeyOut, "", "Location to retreived device private key")
+	flag.StringVar(&valueStore, flagStore, storeOptionMem, "Storage mode - \""+storeOptionMem+"\" or \""+storeOptionFS+"\"")
+	flag.StringVar(&valueStoreDir, flagStoreDir, "store", "Storage directory when store is \""+storeOptionFS+"\"")
+
+	flag.Parse()
+
+	// Check for required arguments
+
+	abort := false
+	if valueCoapURL == "" {
+		fmt.Printf("  --%v required\n", flagCoapURL)
+		abort = true
+	}
+	if valueCoapCert == "" {
+		fmt.Printf("  --%v required\n", flagCoapCert)
+		abort = true
+	}
+	if valueCoapKey == "" {
+		fmt.Printf("  --%v required\n", flagCoapKey)
+		abort = true
+	}
+	if valueMode != modeOptionBootstrap && valueMode != modeOptionLWM2M {
+		fmt.Printf("  --%v required, must be either \"%v\" or \"%v\"\n", flagMode, modeOptionBootstrap, modeOptionLWM2M)
+		abort = true
+	}
+	if valueStore != storeOptionMem && valueStore != storeOptionFS {
+		fmt.Printf("  --%v must be either \"%v\" or \"%v\"\n", flagMode, flagStore, storeOptionFS)
+		abort = true
+	}
+
+	if abort {
+		fmt.Printf("Exited due to invalid arguments\n")
+		os.Exit(1)
+	}
+
+	// Setup storage needed
+
+	var store Store
+	switch valueStore {
+	case storeOptionMem:
+		store = &MemStore{}
+	case storeOptionFS:
+		store = &FsStore{Base: valueStoreDir}
+	default:
+		panic("Invalid store option")
+	}
+
+	// Create device and register
+
+	var device *Device
+	var err error
+	switch valueMode {
+	case modeOptionBootstrap:
+		device, err = DeviceFromBootstrapCredentials(store, valueCoapURL, valueCoapCert, valueCoapKey)
+		if err != nil {
+			log.Fatalf("Failed to setup: %v", err)
+		}
+
+		err = device.Bootstrap(context.Background())
+		if err != nil {
+			log.Fatalf("Failed to bootstrap: %v", err)
+		}
+	case modeOptionLWM2M:
+		device, err = DeviceFromLWM2MCredentials(store, valueCoapURL, valueCoapCert, valueCoapKey)
+		if err != nil {
+			log.Fatalf("Failed to setup: %v", err)
+		}
+	default:
+		panic("Invalid mode option")
+	}
+
+	err = device.Register(context.Background())
+	if err != nil {
+		log.Fatalf("Failed to register: %v", err)
+	}
+
+	// Wrap Up
+
+	printInfo(store)
+
+	if valueCertOut != "" || valueKeyOut != "" {
+		certData, keyData, err := getPemCertAndKey(store)
+		if err != nil {
+			log.Fatalf("Failed to retreive credentials: %v", err)
+		}
+		err = ioutil.WriteFile(valueCertOut, certData, 0700)
+		if err != nil {
+			log.Fatalf("Error writing to file: %v", err)
+		}
+		err = ioutil.WriteFile(valueKeyOut, keyData, 0700)
+		if err != nil {
+			log.Fatalf("Error writing to file: %v", err)
+		}
+	}
+}
+
+func printInfo(store Store) {
+	type ResourceInfo struct {
+		Path        string
+		Description string
+		Printable   bool
+	}
+
+	ri := []ResourceInfo{
+		{Path: "/0/0/0", Description: "LWM2M URL", Printable: true},
+		{Path: "/0/0/3", Description: "Device Certificate", Printable: false},
+		{Path: "/0/0/4", Description: "LWM2M Public Key", Printable: false},
+		{Path: "/0/0/5", Description: "Device Private Key", Printable: false},
+	}
+
+	for _, resource := range ri {
+		value, err := store.Get(resource.Path)
+		if err != nil {
+			fmt.Printf("MISSING RESOURCE: %v - %v\n", resource.Path, resource.Description)
+			continue
+		}
+		if resource.Printable {
+			fmt.Printf("%v - %v: %v\n", resource.Path, resource.Description, string(value))
+		} else {
+			fmt.Printf("%v - %v\n", resource.Path, resource.Description)
+		}
+	}
+}
+
+func getPemCertAndKey(store Store) ([]byte, []byte, error) {
+
+	resource := "/0/0/5"
+	data, err := store.Get(resource)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Cloud not get %v: %w", resource, err)
+	}
+	_, err = x509.ParsePKCS8PrivateKey(data)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Could not convert %v to PKCS8 key: %w", resource, err)
+	}
+	privateKey := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: data,
+	})
+	if privateKey == nil {
+		return nil, nil, fmt.Errorf("Failed to convert private key to PEM")
+	}
+
+	resource = "/0/0/3"
+	data, err = store.Get(resource)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Cloud not get %v: %w", resource, err)
+	}
+	_, err = x509.ParseCertificate(data)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Could not convert %v to Certificate key: %w", resource, err)
+	}
+	certificate := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: data,
+	})
+	if privateKey == nil {
+		return nil, nil, fmt.Errorf("Failed to convert certificate to PEM")
+	}
+
+	return certificate, privateKey, nil
+}

--- a/cmd/lwm2m-bootstrapper/store.go
+++ b/cmd/lwm2m-bootstrapper/store.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"strings"
+)
+
+// Store provides a way to save and retrieve resources
+type Store interface {
+	Get(key string) ([]byte, error)
+	Put(key string, data []byte) error
+}
+
+// FsStore is an implementation of the Store interface
+type FsStore struct {
+	Base string
+}
+
+func escapeKey(key string) string {
+	return strings.ReplaceAll(key, "/", "_")
+}
+
+// Get gets the given key from the filesytem
+func (s *FsStore) Get(key string) ([]byte, error) {
+	location := path.Join(s.Base, escapeKey(key))
+	data, err := ioutil.ReadFile(location)
+	if err != nil {
+		log.Printf("Error reading file: %v", err)
+		return nil, err
+	}
+	return data, nil
+}
+
+// Put writes the given key to the filesytem
+func (s *FsStore) Put(key string, data []byte) error {
+	location := path.Join(s.Base, escapeKey(key))
+	dir := path.Dir(location)
+	err := os.MkdirAll(dir, 0700)
+	if err != nil {
+		log.Printf("Error creating directory: %v", err)
+		return err
+	}
+	err = ioutil.WriteFile(location, data, 0700)
+	if err != nil {
+		log.Printf("Error writing to file: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+// MemStore is an implementation of the Store interface
+type MemStore map[string][]byte
+
+// Get gets the given key from the memory
+func (s *MemStore) Get(key string) ([]byte, error) {
+	if *s == nil {
+		*s = map[string][]byte{}
+	}
+	data, ok := (*s)[key]
+	if ok {
+		copyData := make([]byte, len(data))
+		copy(copyData, data)
+		return copyData, nil
+	}
+	return nil, fmt.Errorf("Not found")
+}
+
+// Put writes the given key to the memory
+func (s *MemStore) Put(key string, data []byte) error {
+	if *s == nil {
+		*s = map[string][]byte{}
+	}
+	copyData := make([]byte, len(data))
+	copy(copyData, data)
+	(*s)[key] = copyData
+
+	return nil
+}

--- a/cmd/lwm2m-bootstrapper/tlv.go
+++ b/cmd/lwm2m-bootstrapper/tlv.go
@@ -1,0 +1,122 @@
+package main
+
+import "fmt"
+
+// TLVType is the type of TLV
+type TLVType int
+
+const (
+	// ObjectInstance is a LWM2M object instance. It contains zero or more Resource and MultiResource
+	ObjectInstance = 0
+	// ResourceInstance is a resource entry of a MultiResource
+	ResourceInstance = 1
+	// MultiResource contains one or more ResourceInstance
+	MultiResource = 2
+	// Resource is a LWM2M resource
+	Resource = 3
+)
+
+func (t TLVType) String() string {
+	switch t {
+	case ObjectInstance:
+		return "Object Instance"
+	case ResourceInstance:
+		return "Resource Instance"
+	case MultiResource:
+		return "Multiple Resource"
+	case Resource:
+		return "Resource"
+	default:
+		return "Invalid"
+	}
+}
+
+// TLV is a parsed LWM2M TLV entry
+type TLV struct {
+	Type       TLVType
+	Identifier int
+	Value      []byte
+	Children   []TLV
+}
+
+// TLVFromBytes loads a TLV from the given bytes
+func TLVFromBytes(data []byte) (*TLV, []byte, error) {
+	t := TLV{}
+
+	if len(data) < 1 {
+		return nil, nil, fmt.Errorf("Data short to be a valid TLV")
+	}
+
+	typeField := int(data[0])
+	t.Type = TLVType((data[0] >> 6) & 0x3)
+	data = data[1:]
+
+	if typeField&(1<<5) == 0 {
+		if len(data) < 1 {
+			return nil, nil, fmt.Errorf("Data short to be a valid TLV")
+		}
+		t.Identifier = int(data[0])
+		data = data[1:]
+	} else {
+		if len(data) < 2 {
+			return nil, nil, fmt.Errorf("Data short to be a valid TLV")
+		}
+		t.Identifier = (int(data[0]) << 8) | (int(data[1]) << 0)
+		data = data[2:]
+	}
+
+	lengthBytes := (typeField >> 3) & 0x3
+	length := 0
+	if lengthBytes == 0 {
+
+		// No length field, the value immediately follows the Identifier field in is of the length indicated by Bits 2-0 of this field
+		length = (typeField >> 0) & 0x7
+	} else {
+
+		// The Length field is lengthBytes and Bits 2-0 MUST be ignored
+		if len(data) < lengthBytes {
+			return nil, nil, fmt.Errorf("Data short to be a valid TLV. Needed %v, got %v", lengthBytes, len(data))
+		}
+		for i := 0; i < lengthBytes; i++ {
+			length = (length << 8) | int(data[i])
+		}
+		data = data[lengthBytes:]
+	}
+	if len(data) < length {
+		return nil, nil, fmt.Errorf("Data short to be a valid TLV. Needed %v, got %v", length, len(data))
+	}
+	t.Value = make([]byte, length)
+	copy(t.Value, data)
+	data = data[length:]
+
+	if (t.Type == ObjectInstance) || (t.Type == MultiResource) {
+		childData := t.Value
+		for len(childData) > 0 {
+			var child *TLV
+			var err error
+			child, childData, err = TLVFromBytes(childData)
+			if err != nil {
+				return nil, nil, err
+			}
+			t.Children = append(t.Children, *child)
+		}
+	}
+
+	return &t, data, nil
+}
+
+func (t *TLV) String() string {
+	return fmt.Sprintf("Type='%v', ID=%v, Size=%v, Children=%v", t.Type, t.Identifier, len(t.Value), len(t.Children))
+}
+
+// Print displays the TLV
+func (t *TLV) Print() {
+	t.print("")
+}
+
+func (t *TLV) print(prefix string) {
+	fmt.Printf("%v%v\n", prefix, t)
+	for _, child := range t.Children {
+		child.print(prefix + "  ")
+	}
+}

--- a/cmd/lwm2m-bootstrapper/tlv_test.go
+++ b/cmd/lwm2m-bootstrapper/tlv_test.go
@@ -1,0 +1,211 @@
+package main_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/c1728p9/lwm2m"
+)
+
+type TLVResult struct {
+	Type       TLVType
+	Identifier int
+	Length     int
+	Children   []TLVResult
+}
+
+// 6.4.3.2 Multiple Object Instance Request Examples
+var testDataMultiObject []byte = []byte{
+	0x08, 0x00, 0x79,
+	0xC8, 0x00, 0x14, 0x4F, 0x70, 0x65, 0x6E, 0x20, 0x4D, 0x6F, 0x62, 0x69, 0x6C, 0x65, 0x20, 0x41, 0x6C, 0x6C, 0x69, 0x61, 0x6E, 0x63, 0x65,
+	0xC8, 0x01, 0x16, 0x4C, 0x69, 0x67, 0x68, 0x74, 0x77, 0x65, 0x69, 0x67, 0x68, 0x74, 0x20, 0x4D, 0x32, 0x4D, 0x20, 0x43, 0x6C, 0x69, 0x65, 0x6E, 0x74,
+	0xC8, 0x02, 0x09, 0x33, 0x34, 0x35, 0x30, 0x30, 0x30, 0x31, 0x32, 0x33,
+	0xC3, 0x03, 0x31, 0x2E, 0x30,
+	0x86, 0x06,
+	0x41, 0x00, 0x01,
+	0x41, 0x01, 0x05,
+	0x88, 0x07, 0x08,
+	0x42, 0x00, 0x0E, 0xD8,
+	0x42, 0x01, 0x13, 0x88,
+	0x87, 0x08,
+	0x41, 0x00, 0x7D,
+	0x42, 0x01, 0x03, 0x84,
+	0xC1, 0x09, 0x64,
+	0xC1, 0x0A, 0x0F,
+	0x83, 0x0B,
+	0x41, 0x00, 0x00,
+	0xC4, 0x0D, 0x51, 0x82, 0x42, 0x8F,
+	0xC6, 0x0E, 0x2B, 0x30, 0x32, 0x3A, 0x30, 0x30,
+	0xC1, 0x10, 0x55,
+}
+
+var testResultMultiObject TLVResult = TLVResult{
+	Type:       ObjectInstance,
+	Identifier: 0x00,
+	Length:     121,
+	Children: []TLVResult{
+		{
+			Type:       Resource,
+			Identifier: 0x00,
+			Length:     20,
+			Children:   nil,
+		},
+		{
+			Type:       Resource,
+			Identifier: 0x01,
+			Length:     22,
+			Children:   nil,
+		},
+		{
+			Type:       Resource,
+			Identifier: 0x02,
+			Length:     9,
+			Children:   nil,
+		},
+		{
+			Type:       Resource,
+			Identifier: 0x03,
+			Length:     3,
+			Children:   nil,
+		},
+		{
+			Type:       MultiResource,
+			Identifier: 0x06,
+			Length:     6,
+			Children: []TLVResult{
+				{
+					Type:       ResourceInstance,
+					Identifier: 0x00,
+					Length:     1,
+					Children:   nil,
+				},
+				{
+					Type:       ResourceInstance,
+					Identifier: 0x01,
+					Length:     1,
+					Children:   nil,
+				},
+			},
+		},
+		{
+			Type:       MultiResource,
+			Identifier: 0x07,
+			Length:     8,
+			Children: []TLVResult{
+				{
+					Type:       ResourceInstance,
+					Identifier: 0x00,
+					Length:     2,
+					Children:   nil,
+				},
+				{
+					Type:       ResourceInstance,
+					Identifier: 0x01,
+					Length:     2,
+					Children:   nil,
+				},
+			},
+		},
+		{
+			Type:       MultiResource,
+			Identifier: 0x08,
+			Length:     7,
+			Children: []TLVResult{
+				{
+					Type:       ResourceInstance,
+					Identifier: 0x00,
+					Length:     1,
+					Children:   nil,
+				},
+				{
+					Type:       ResourceInstance,
+					Identifier: 0x01,
+					Length:     2,
+					Children:   nil,
+				},
+			},
+		},
+		{
+			Type:       Resource,
+			Identifier: 0x09,
+			Length:     1,
+			Children:   nil,
+		},
+		{
+			Type:       Resource,
+			Identifier: 0x0A,
+			Length:     1,
+			Children:   nil,
+		},
+		{
+			Type:       MultiResource,
+			Identifier: 0x0B,
+			Length:     3,
+			Children: []TLVResult{
+				{
+					Type:       ResourceInstance,
+					Identifier: 0x00,
+					Length:     1,
+					Children:   nil,
+				},
+			},
+		},
+		{
+			Type:       Resource,
+			Identifier: 0x0D,
+			Length:     4,
+			Children:   nil,
+		},
+		{
+			Type:       Resource,
+			Identifier: 0x0E,
+			Length:     6,
+			Children:   nil,
+		},
+		{
+			Type:       Resource,
+			Identifier: 0x10,
+			Length:     1,
+			Children:   nil,
+		},
+	},
+}
+
+func compareTLV(expected TLVResult, actual TLV) error {
+	if expected.Type != actual.Type {
+		return fmt.Errorf("Expected Type '%v', got '%v'", expected.Type, actual.Type)
+	}
+	if expected.Identifier != actual.Identifier {
+		return fmt.Errorf("Expected Identifier '%v', got '%v'", expected.Identifier, actual.Identifier)
+	}
+	if expected.Length != len(actual.Value) {
+		return fmt.Errorf("Expected Data Length '%v', got '%v'", expected.Length, len(actual.Value))
+	}
+
+	if len(expected.Children) != len(actual.Children) {
+		return fmt.Errorf("Expected len(Children) '%v', got '%v'", len(expected.Children), len(actual.Children))
+	}
+	for i, expectedChild := range expected.Children {
+		actualChild := actual.Children[i]
+		childError := compareTLV(expectedChild, actualChild)
+		if childError != nil {
+			return fmt.Errorf("Child[%v] mismatch: %w", i, childError)
+		}
+	}
+	return nil
+}
+
+func TestTLV(t *testing.T) {
+	tlv, remain, err := TLVFromBytes(testDataMultiObject)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = compareTLV(testResultMultiObject, *tlv)
+	if err != nil {
+		t.Error(err)
+	}
+
+	tlv.Print()
+	fmt.Printf("%v bytes remaining\n", len(remain))
+}

--- a/cmd/virtual-kubelet/internal/commands/stress/scripts/generate-kubeconfigs.sh
+++ b/cmd/virtual-kubelet/internal/commands/stress/scripts/generate-kubeconfigs.sh
@@ -1,17 +1,30 @@
 #!/bin/bash
 
 set -e
-#set -x
+set -u
 
-if [ -z "$4" ]
+if [ -z "$API_HOST" ]; then
+    echo "API_HOST must be set to target enviroment."
+    echo "  Production example:     export API_HOST=\"https://api.us-east-1.mbedcloud.com\""
+    echo "  OS2 example:            export API_HOST=\"https://api-os2.mbedcloudstaging.net\""
+    echo "  Integration example:    export API_HOST=\"https://lab-api.mbedcloudintegration.net\""
+    exit 1
+fi
+if [ -z "$ACCESS_KEY" ]; then
+    echo "ACCESS_KEY must be set to an access key for your account"
+    echo "  Example: export ACCESS_KEY=\"ak_2MDE3MmRkNDIwN2UwODIwM2JhNzA2ODMwMDAwMDAwMDA0176e387ab7f2242d8a8b6ae...\""
+    exit 1
+fi
+
+if [ -z "${4:-""}" ]
 then
-    echo "Usage: generate-kubeconfigs.sh <SERVER_URI> <ACCOUNT_ID> <NUMBER> <OUTPUT_DIRECTORY>"
+    echo "Usage: generate-kubeconfigs.sh <SERVER_URI> <PREFIX> <NUMBER> <OUTPUT_DIRECTORY>"
 
     exit 1
 fi
 
 export SERVER_URI=$1
-export ACCOUNT_ID=$2
+PREFIX=$2
 N=$3
 OUT_DIR=$4
 
@@ -21,21 +34,97 @@ if [ ! -d "$OUT_DIR" ]; then
     exit 1
 fi
 
+TMP=$(mktemp -d)
+CA_DIR="$TMP/ca"
+CA_UPLOAD_NAME="$PREFIX-ca"
+SERVICE="bootstrap"
+BOOTSTRAP_URL="$(curl -X GET -s -S --fail "$API_HOST/v3/server-credentials" -H "accept: application/json" -H "Content-Type: application/json" -H "Authorization: Bearer $ACCESS_KEY" | jq -r -e ".bootstrap.url")"
+JOB_MAX="${JOB_MAX:-100}"
+
+# Make bootstrap CA
+echo "Making bootstrap CA"
+mkdir "$CA_DIR"
+(
+cd "$CA_DIR"
+openssl ecparam -out CA_private.pem -name prime256v1 -genkey
+(echo '[req]'; echo 'distinguished_name=dn'; echo 'prompt=no'; echo '[dn]'; echo 'CN=CA'; echo '[ext]'; echo 'basicConstraints=CA:TRUE') > ca.cnf
+openssl req -key CA_private.pem -new -sha256 -x509 -days 12775 -out CA_cert.pem -config ca.cnf -extensions ext
+)
+
+# Upload bootstrap CA
+echo "Uploading bootstrap CA"
+CA_CERT_DATA="$(cat "$CA_DIR/CA_cert.pem")"
+POST_DATA="$(jq -n --arg ca_cert_name "$CA_UPLOAD_NAME" --arg ca_cert_data "$CA_CERT_DATA" --arg service "$SERVICE" '{"name": $ca_cert_name, "certificate": $ca_cert_data, "service": $service}')"
+RESULT="$(curl -X POST -s -S --fail "$API_HOST/v3/trusted-certificates" -H "Authorization: Bearer $ACCESS_KEY" -H "content-type: application/json" -d "$POST_DATA")"
+CERT_ID=$(echo "$RESULT" | jq -e -r ".id")
+
+# Reusable code to run jobs in parallel
+job_init() {
+    JOB_NAMES=()                # Names of each job
+    JOB_PIDS=()                 # PIDS of each job
+    JOB_ERRORS=()               # sparse list of non-zero return codes
+    JOB_MAX="${JOB_MAX:-20}"    # Number of jobs to run in parallel, default 20
+    JOB_POS_NEXT_=0  # internal
+    JOB_POS_WAIT_=0  # internal
+}
+job_wait_limit_() {
+    local MAX_JOBS=$1
+    while [ $(( JOB_POS_NEXT_ - JOB_POS_WAIT_ )) -gt $MAX_JOBS ]; do
+        wait "${JOB_PIDS[$JOB_POS_WAIT_]}" || JOB_ERRORS[$JOB_POS_WAIT_]="$?"
+        JOB_POS_WAIT_=$(( JOB_POS_WAIT_ + 1 ))
+    done
+}
+job_add() {
+    local NAME="$1"
+    local PID="$2"
+    JOB_NAMES[$JOB_POS_NEXT_]=$NAME
+    JOB_PIDS[$JOB_POS_NEXT_]=$PID
+    JOB_POS_NEXT_=$(( JOB_POS_NEXT_ + 1 ))
+    job_wait_limit_ $(( JOB_MAX - 1 ))
+}
+job_wait_all() {
+    job_wait_limit_ 0
+}
+
+# Generate certificates (do bootstrap in the background)
+job_init
 while [ "$N" -gt 0 ]; do
-    export DEVICE_ID="$(uuid | sed 's/-//g')"
+    ENDPOINT_NAME="$PREFIX-$N"
+    BOOTSTRAP_CERT_FILE="$TMP/$ENDPOINT_NAME-bsCert.pem"
+    BOOTSTRAP_KEY_FILE="$TMP/$ENDPOINT_NAME-bsKey.pem"
+    KUBE_CERT_FILE="$TMP/$ENDPOINT_NAME-kubelet.crt"
+    KUBE_KEY_FILE="$TMP/$ENDPOINT_NAME-kubelet.key"
 
-    # Generate self-signed device certificate
-    openssl req \
-        -x509 \
-        -nodes \
-        -newkey rsa:2048 \
-        -keyout /tmp/kubelet.key \
-        -out /tmp/kubelet.crt \
-        -subj "/C=US/ST=TX/L=$DEVICE_ID/O=my_o/OU=$ACCOUNT_ID/CN=$DEVICE_ID/emailAddress=email@example.com" \
-        -days 365
+    # Generate bootstrap certificates
+    openssl ecparam -out "$BOOTSTRAP_KEY_FILE" -name prime256v1 -genkey
+    openssl req -key "$BOOTSTRAP_KEY_FILE" -new -sha256 -out "$BOOTSTRAP_CERT_FILE.tmp" -subj "/CN=$ENDPOINT_NAME"
+    openssl x509 -req -in "$BOOTSTRAP_CERT_FILE.tmp" -sha256 -out "$BOOTSTRAP_CERT_FILE" -CA "$CA_DIR/CA_cert.pem" -CAkey "$CA_DIR/CA_private.pem" -CAcreateserial -days 3650
+    rm "$BOOTSTRAP_CERT_FILE.tmp"
 
-    export CLIENT_CERT="$(cat /tmp/kubelet.crt | base64 -w0)"
-    export CLIENT_KEY="$(cat /tmp/kubelet.key | base64 -w0)"
-    echo "$(cat kubeconfig.yaml.tpl | envsubst)" > $OUT_DIR/$DEVICE_ID.kubeconfig
+    # Bootstrap in the background
+    (
+    lwm2m-bootstrapper --mode bootstrap  \
+    --coap-cert "$BOOTSTRAP_CERT_FILE" --coap-key "$BOOTSTRAP_KEY_FILE" --coap-url "$BOOTSTRAP_URL" \
+    --dump-cert "$KUBE_CERT_FILE" --dump-key "$KUBE_KEY_FILE" > /dev/null 2> /dev/null
+
+    export CLIENT_CERT="$(cat "$KUBE_CERT_FILE" | base64 -w0)"
+    export CLIENT_KEY="$(cat "$KUBE_KEY_FILE" | base64 -w0)"
+    echo "$(cat kubeconfig.yaml.tpl | envsubst)" > $OUT_DIR/$ENDPOINT_NAME.kubeconfig
+    )&
+    job_add "$ENDPOINT_NAME" "$!"
+
     N=$(( N - 1 ))
 done
+job_wait_all
+
+# Print any errors that occurred
+echo "Certificates created, ${#JOB_ERRORS[@]} errors occurred"
+for I in "${!JOB_ERRORS[@]}"; do
+    echo "  Error generating certificate for ${JOB_NAMES[$I]}: returned ${JOB_ERRORS[$I]}"
+done
+
+# Delete uploaded CA and temp files
+curl -X DELETE -s -S --fail "$API_HOST/v3/trusted-certificates/$CERT_ID" -H "Authorization: Bearer $ACCESS_KEY"
+rm -r "$TMP"
+
+echo "Generating configs completed successfully"

--- a/cmd/virtual-kubelet/internal/commands/stress/scripts/generate-kubeconfigs.sh
+++ b/cmd/virtual-kubelet/internal/commands/stress/scripts/generate-kubeconfigs.sh
@@ -51,6 +51,13 @@ openssl ecparam -out CA_private.pem -name prime256v1 -genkey
 openssl req -key CA_private.pem -new -sha256 -x509 -days 12775 -out CA_cert.pem -config ca.cnf -extensions ext
 )
 
+# If a certificate with the same name exists delete it so the upload doesn't fail
+echo "Checking for conflicting CA"
+if CERT_ID_OLD="$(curl -X GET -s -S --fail "$API_HOST/v3/trusted-certificates?name__eq=$CA_UPLOAD_NAME"  -H "Authorization: Bearer $ACCESS_KEY" | jq -e -r ".data[0].id")"; then
+    echo "Deleting conflicting CA \"$CERT_ID_OLD\""
+    curl -X DELETE -s -S --fail "$API_HOST/v3/trusted-certificates/$CERT_ID_OLD" -H "Authorization: Bearer $ACCESS_KEY"
+fi
+
 # Upload bootstrap CA
 echo "Uploading bootstrap CA"
 CA_CERT_DATA="$(cat "$CA_DIR/CA_cert.pem")"

--- a/cmd/virtual-kubelet/internal/commands/stress/scripts/kubeconfig.yaml.tpl
+++ b/cmd/virtual-kubelet/internal/commands/stress/scripts/kubeconfig.yaml.tpl
@@ -6,13 +6,13 @@ clusters:
 contexts:
 - context:
     cluster: kaas
-    user: $DEVICE_ID
+    user: kubelet
   name: kaas
 current-context: kaas
 kind: Config
 preferences: {}
 users:
-- name: $DEVICE_ID
+- name: kubelet
   user:
     client-certificate-data: $CLIENT_CERT
     client-key-data: $CLIENT_KEY

--- a/scripts/stress-test.sh
+++ b/scripts/stress-test.sh
@@ -2,17 +2,24 @@
 
 set -e
 
-if [ -z "$3" ]
+if [ -z "$4" ]
 then
-    echo "Usage: stress-test.sh <SERVER_URI> <ACCOUNT_ID> <NUMBER>"
+    echo "Usage: stress-test.sh <KaaS URL> <API Gateway> <Access Key> <Number> [prefix]"
 
     exit 1
 fi
+# KaaS URL, API Gateway, Access Key, Number
+kaas_url=$1
+export API_HOST=$2
+export ACCESS_KEY=$3
+number=$4
+
+prefix=${5:-virtual-kubelet}
 
 kubeconfigs_dir=/tmp/kubeconfigs
 provider_config=/tmp/mock.json
 
 mkdir -p $kubeconfigs_dir
 echo "{}" > $provider_config
-./generate-kubeconfigs.sh $1 $2 $3 $kubeconfigs_dir
+./generate-kubeconfigs.sh $kaas_url $prefix $number $kubeconfigs_dir
 virtual-kubelet stress --provider mock --provider-config $provider_config --kubeconfigs $kubeconfigs_dir


### PR DESCRIPTION
Process for getting a certificate:
- Create CA locally
- Upload CA cert to Pelion
- Generate device certificates
- Bootstrap devices to get production certificates
- Delete CA that was uploaded (cleanup)

To perform bootstrap the program lwm2m-bootstrapper is used. This code is located in cmd/lwm2m-bootstrapper and was copied from: https://github.com/pelioniot/lwm2m-bootstrapper

Bootstrap can take several seconds to complete. To allow for generating a large number of certificates quickly bootstrap is done in parallel in generate-kubeconfigs.sh.